### PR TITLE
Improve training accuracy

### DIFF
--- a/main.py
+++ b/main.py
@@ -4,7 +4,6 @@ import argparse
 import torch
 
 from song_recognizer.train import train
-from song_recognizer.recognition import record_audio, predict
 from song_recognizer.model import SongRecognizer
 
 
@@ -18,6 +17,7 @@ def cmd_train(args: argparse.Namespace) -> None:
 
 
 def cmd_predict(args: argparse.Namespace) -> None:
+    from song_recognizer.recognition import record_audio, predict
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
     model = SongRecognizer(num_classes=args.num_classes)
     model.load_state_dict(torch.load(MODEL_PATH, map_location=device))

--- a/song_recognizer/data.py
+++ b/song_recognizer/data.py
@@ -32,5 +32,9 @@ class AudioDataset(Dataset):
         if waveform.ndim > 1:
             waveform = torch.mean(waveform, dim=0, keepdim=True)
         mel = self.transform(waveform)
+        # Resize to a fixed size for batching
+        mel = torch.nn.functional.interpolate(
+            mel.unsqueeze(0), size=(64, 64), mode="bilinear", align_corners=False
+        ).squeeze(0)
         label = idx  # Each file is its own label
         return mel, label


### PR DESCRIPTION
## Summary
- add lazy imports for prediction module to avoid PortAudio dependency during training
- resize mel spectrograms to 64×64 for consistent batching

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f5915cc50832fa023ccbac8adbe06